### PR TITLE
Cleaning up some tags to pass w3c validation, aligning the differences between wp_enqueue methods

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,16 +2,18 @@ sudo: false
 
 language: php
 
+# Receive notifications for build results.
+# @link http://docs.travis-ci.com/user/notifications/#Email-notifications
 notifications:
-  email:
-    on_success: never
-    on_failure: change
+    email: false
 
 branches:
   only:
-    - master
+    - production
 
 matrix:
+  fast_finish: true
+
   include:
     - php: 5.6
       env: WP_VERSION=latest PHP_LINT=1

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,42 @@
+sudo: false
+
+language: php
+
+notifications:
+  email:
+    on_success: never
+    on_failure: change
+
+branches:
+  only:
+    - master
+
+matrix:
+  include:
+    - php: 5.6
+      env: WP_VERSION=latest PHP_LINT=1
+    - php: 7.0
+      env: WP_VERSION=latest PHP_LINT=1
+    # - php: 5.6
+    #   env: WP_VERSION=nightly WP_PHPCS=1
+    - php: 7.2
+      env: WP_VERSION=nightly PHP_LINT=1
+  fast_finish: true
+
+before_script:
+  - |
+    if [[ ! -z "$WP_VERSION" ]] ; then
+      bash bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION
+    fi
+  - |
+    if [[ "$WP_PHPCS" == "1" ]]; then
+      composer install
+      export PATH=$PATH:${PWD}/vendor/bin/
+      # After CodeSniffer install you should refresh your path.
+      phpenv rehash
+    fi
+
+script:
+  - if [[ "$PHP_LINT" == "1" ]]; then find . -type "f" -iname "*.php" | xargs -L "1" php -l; fi
+  - if [[ "$WP_PHPCS" == "1" ]]; then phpcs -p -s -v -n --standard=./codesniffer.ruleset.xml --extensions=php .; fi
+  - phpunit

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+
+if [ $# -lt 3 ]; then
+	echo "usage: $0 <db-name> <db-user> <db-pass> [db-host] [wp-version]"
+	exit 1
+fi
+
+DB_NAME=$1
+DB_USER=$2
+DB_PASS=$3
+DB_HOST=${4-localhost}
+WP_VERSION=${5-latest}
+
+WP_TESTS_DIR=${WP_TESTS_DIR-/tmp/wordpress-tests-lib}
+WP_CORE_DIR=${WP_CORE_DIR-/tmp/wordpress/}
+
+download() {
+    if [ `which curl` ]; then
+        curl -s "$1" > "$2";
+    elif [ `which wget` ]; then
+        wget -nv -O "$2" "$1"
+    fi
+}
+
+if [[ $WP_VERSION =~ [0-9]+\.[0-9]+(\.[0-9]+)? ]]; then
+	WP_TESTS_TAG="tags/$WP_VERSION"
+elif [[ $WP_VERSION == 'nightly' || $WP_VERSION == 'trunk' ]]; then
+	WP_TESTS_TAG="trunk"
+else
+	# http serves a single offer, whereas https serves multiple. we only want one
+	download http://api.wordpress.org/core/version-check/1.7/ /tmp/wp-latest.json
+	grep '[0-9]+\.[0-9]+(\.[0-9]+)?' /tmp/wp-latest.json
+	LATEST_VERSION=$(grep -o '"version":"[^"]*' /tmp/wp-latest.json | sed 's/"version":"//')
+	if [[ -z "$LATEST_VERSION" ]]; then
+		echo "Latest WordPress version could not be found"
+		exit 1
+	fi
+	WP_TESTS_TAG="tags/$LATEST_VERSION"
+fi
+
+set -ex
+
+install_wp() {
+
+	if [ -d $WP_CORE_DIR ]; then
+		return;
+	fi
+
+	mkdir -p $WP_CORE_DIR
+
+	if [[ $WP_VERSION == 'nightly' || $WP_VERSION == 'trunk' ]]; then
+		mkdir -p /tmp/wordpress-nightly
+		download https://wordpress.org/nightly-builds/wordpress-latest.zip  /tmp/wordpress-nightly/wordpress-nightly.zip
+		unzip -q /tmp/wordpress-nightly/wordpress-nightly.zip -d /tmp/wordpress-nightly/
+		mv /tmp/wordpress-nightly/wordpress/* $WP_CORE_DIR
+	else
+		if [ $WP_VERSION == 'latest' ]; then
+			local ARCHIVE_NAME='latest'
+		else
+			local ARCHIVE_NAME="wordpress-$WP_VERSION"
+		fi
+		download https://wordpress.org/${ARCHIVE_NAME}.tar.gz  /tmp/wordpress.tar.gz
+		tar --strip-components=1 -zxmf /tmp/wordpress.tar.gz -C $WP_CORE_DIR
+	fi
+
+	download https://raw.github.com/markoheijnen/wp-mysqli/master/db.php $WP_CORE_DIR/wp-content/db.php
+}
+
+install_test_suite() {
+	# portable in-place argument for both GNU sed and Mac OSX sed
+	if [[ $(uname -s) == 'Darwin' ]]; then
+		local ioption='-i .bak'
+	else
+		local ioption='-i'
+	fi
+
+	# set up testing suite if it doesn't yet exist
+	if [ ! -d $WP_TESTS_DIR ]; then
+		# set up testing suite
+		mkdir -p $WP_TESTS_DIR
+		svn co --quiet https://develop.svn.wordpress.org/${WP_TESTS_TAG}/tests/phpunit/includes/ $WP_TESTS_DIR/includes
+	fi
+
+	if [ ! -f wp-tests-config.php ]; then
+		download https://develop.svn.wordpress.org/${WP_TESTS_TAG}/wp-tests-config-sample.php "$WP_TESTS_DIR"/wp-tests-config.php
+		sed $ioption "s:dirname( __FILE__ ) . '/src/':'$WP_CORE_DIR':" "$WP_TESTS_DIR"/wp-tests-config.php
+		sed $ioption "s/youremptytestdbnamehere/$DB_NAME/" "$WP_TESTS_DIR"/wp-tests-config.php
+		sed $ioption "s/yourusernamehere/$DB_USER/" "$WP_TESTS_DIR"/wp-tests-config.php
+		sed $ioption "s/yourpasswordhere/$DB_PASS/" "$WP_TESTS_DIR"/wp-tests-config.php
+		sed $ioption "s|localhost|${DB_HOST}|" "$WP_TESTS_DIR"/wp-tests-config.php
+	fi
+
+}
+
+install_db() {
+	# parse DB_HOST for port or socket references
+	local PARTS=(${DB_HOST//\:/ })
+	local DB_HOSTNAME=${PARTS[0]};
+	local DB_SOCK_OR_PORT=${PARTS[1]};
+	local EXTRA=""
+
+	if ! [ -z $DB_HOSTNAME ] ; then
+		if [ $(echo $DB_SOCK_OR_PORT | grep -e '^[0-9]\{1,\}$') ]; then
+			EXTRA=" --host=$DB_HOSTNAME --port=$DB_SOCK_OR_PORT --protocol=tcp"
+		elif ! [ -z $DB_SOCK_OR_PORT ] ; then
+			EXTRA=" --socket=$DB_SOCK_OR_PORT"
+		elif ! [ -z $DB_HOSTNAME ] ; then
+			EXTRA=" --host=$DB_HOSTNAME --protocol=tcp"
+		fi
+	fi
+
+	# create database
+	mysqladmin create $DB_NAME --user="$DB_USER" --password="$DB_PASS"$EXTRA
+}
+
+install_wp
+install_test_suite
+install_db

--- a/php/class-asset-manager-styles.php
+++ b/php/class-asset-manager-styles.php
@@ -93,11 +93,11 @@ class Asset_Manager_Styles extends Asset_Manager {
 				}
 
 				if ( 'preload' === $stylesheet['load_method'] ) {
-					$print_string = '<link rel="preload" href="%1$s" class="%2$s" media="%3$s" as="style" onload="this.rel=\'stylesheet\'"></link><noscript><link rel="stylesheet" href="%1$s" class="%2$s" media="%3$s"></link></noscript>';
+					$print_string = '<link rel="preload" href="%1$s" class="%2$s" media="%3$s" as="style" onload="this.rel=\'stylesheet\'"></link><noscript><link rel="stylesheet" href="%1$s" class="%2$s" media="%3$s" /></noscript>';
 				} elseif ( 'async' === $stylesheet['load_method'] ) {
-					$print_string = '<script class="%2$s" type="text/javascript">loadCSS("%1$s");</script><noscript><link rel="stylesheet" href="%1$s" class="%2$s" media="%3$s"></link></noscript>';
+					$print_string = '<script class="%2$s" type="text/javascript">loadCSS("%1$s");</script><noscript><link rel="stylesheet" href="%1$s" class="%2$s" media="%3$s" /></noscript>';
 				} elseif ( 'defer' === $stylesheet['load_method'] ) {
-					$print_string = '<script class="%2$s" type="text/javascript">document.addEventListener("DOMContentLoaded",function(){loadCSS("%1$s");});</script><noscript><link rel="stylesheet" href="%1$s" class="%2$s" media="%3$s"></link></noscript>';
+					$print_string = '<script class="%2$s" type="text/javascript">document.addEventListener("DOMContentLoaded",function(){loadCSS("%1$s");});</script><noscript><link rel="stylesheet" href="%1$s" class="%2$s" media="%3$s" /></noscript>';
 				}
 
 				echo wp_kses(

--- a/php/class-asset-manager-styles.php
+++ b/php/class-asset-manager-styles.php
@@ -93,18 +93,18 @@ class Asset_Manager_Styles extends Asset_Manager {
 				}
 
 				if ( 'preload' === $stylesheet['load_method'] ) {
-					$print_string = '<link rel="preload" href="%1$s" class="%2$s" %3$s as="style" onload="this.rel=\'stylesheet\'"></link><noscript><link rel="stylesheet" href="%1$s" class="%2$s" %3$s /></noscript>';
+					$print_string = '<link rel="preload" href="%1$s" class="%2$s" %3$s as="style" onload="this.rel=\'stylesheet\'" /><noscript><link rel="stylesheet" href="%1$s" class="%2$s" %3$s/></noscript>';
 				} elseif ( 'async' === $stylesheet['load_method'] ) {
-					$print_string = '<script class="%2$s" type="text/javascript">loadCSS("%1$s");</script><noscript><link rel="stylesheet" href="%1$s" class="%2$s" %3$s /></noscript>';
+					$print_string = '<script class="%2$s" type="text/javascript">loadCSS("%1$s");</script><noscript><link rel="stylesheet" href="%1$s" class="%2$s" %3$s/></noscript>';
 				} elseif ( 'defer' === $stylesheet['load_method'] ) {
-					$print_string = '<script class="%2$s" type="text/javascript">document.addEventListener("DOMContentLoaded",function(){loadCSS("%1$s");});</script><noscript><link rel="stylesheet" href="%1$s" class="%2$s" %3$s /></noscript>';
+					$print_string = '<script class="%2$s" type="text/javascript">document.addEventListener("DOMContentLoaded",function(){loadCSS("%1$s");});</script><noscript><link rel="stylesheet" href="%1$s" class="%2$s" %3$s/></noscript>';
 				}
 
 				echo wp_kses(
 					sprintf( $print_string,
 						esc_url( $src ),
 						esc_attr( implode( ' ', $classes ) ),
-						! empty( $media ) ? sprintf( 'media="%s"', esc_attr( $media ) ) : ''
+						! empty( $media ) ? sprintf( 'media="%s" ', esc_attr( $media ) ) : ''
 					),
 					array(
 						'link' => array(

--- a/php/class-asset-manager-styles.php
+++ b/php/class-asset-manager-styles.php
@@ -93,7 +93,7 @@ class Asset_Manager_Styles extends Asset_Manager {
 				}
 
 				if ( 'preload' === $stylesheet['load_method'] ) {
-					$print_string = '<link rel="preload" href="%1$s" class="%2$s" %3$s as="style" onload="this.rel=\'stylesheet\'"></link><noscript><link rel="stylesheet" href="%1$s" class="%2$s" media="%3$s" /></noscript>';
+					$print_string = '<link rel="preload" href="%1$s" class="%2$s" %3$s as="style" onload="this.rel=\'stylesheet\'"></link><noscript><link rel="stylesheet" href="%1$s" class="%2$s" %3$s /></noscript>';
 				} elseif ( 'async' === $stylesheet['load_method'] ) {
 					$print_string = '<script class="%2$s" type="text/javascript">loadCSS("%1$s");</script><noscript><link rel="stylesheet" href="%1$s" class="%2$s" %3$s /></noscript>';
 				} elseif ( 'defer' === $stylesheet['load_method'] ) {

--- a/php/class-asset-manager-styles.php
+++ b/php/class-asset-manager-styles.php
@@ -93,18 +93,18 @@ class Asset_Manager_Styles extends Asset_Manager {
 				}
 
 				if ( 'preload' === $stylesheet['load_method'] ) {
-					$print_string = '<link rel="preload" href="%1$s" class="%2$s" media="%3$s" as="style" onload="this.rel=\'stylesheet\'"></link><noscript><link rel="stylesheet" href="%1$s" class="%2$s" media="%3$s" /></noscript>';
+					$print_string = '<link rel="preload" href="%1$s" class="%2$s" %3$s as="style" onload="this.rel=\'stylesheet\'"></link><noscript><link rel="stylesheet" href="%1$s" class="%2$s" media="%3$s" /></noscript>';
 				} elseif ( 'async' === $stylesheet['load_method'] ) {
-					$print_string = '<script class="%2$s" type="text/javascript">loadCSS("%1$s");</script><noscript><link rel="stylesheet" href="%1$s" class="%2$s" media="%3$s" /></noscript>';
+					$print_string = '<script class="%2$s" type="text/javascript">loadCSS("%1$s");</script><noscript><link rel="stylesheet" href="%1$s" class="%2$s" %3$s /></noscript>';
 				} elseif ( 'defer' === $stylesheet['load_method'] ) {
-					$print_string = '<script class="%2$s" type="text/javascript">document.addEventListener("DOMContentLoaded",function(){loadCSS("%1$s");});</script><noscript><link rel="stylesheet" href="%1$s" class="%2$s" media="%3$s" /></noscript>';
+					$print_string = '<script class="%2$s" type="text/javascript">document.addEventListener("DOMContentLoaded",function(){loadCSS("%1$s");});</script><noscript><link rel="stylesheet" href="%1$s" class="%2$s" %3$s /></noscript>';
 				}
 
 				echo wp_kses(
 					sprintf( $print_string,
 						esc_url( $src ),
 						esc_attr( implode( ' ', $classes ) ),
-						esc_attr( $media )
+						! empty( $media ) ? sprintf( 'media="%s"', esc_attr( $media ) ) : ''
 					),
 					array(
 						'link' => array(

--- a/php/class-asset-manager.php
+++ b/php/class-asset-manager.php
@@ -264,9 +264,13 @@ abstract class Asset_Manager {
 				$args['load_method'] = 'sync';
 			}
 
-			// Set in footer value based on load_hook
-			if ( empty( $args['in_footer'] ) ) {
-				$args['in_footer'] = ! empty( $args['load_hook'] ) && 'wp_footer' === $args['load_hook'] ? true : false;
+			// Set in footer value based on load_hook.
+			if ( 'style' !== $args['type'] ) {
+				if ( empty( $args['in_footer'] ) ) {
+					$args['in_footer'] = ! empty( $args['load_hook'] ) && 'wp_footer' === $args['load_hook'] ? true : false;
+				}
+			} elseif ( empty( $args['media'] ) ) {
+				$args['media'] = 'all';
 			}
 
 			// Set load_hook value based on in_footer
@@ -279,7 +283,13 @@ abstract class Asset_Manager {
 			// Enqueue asset if applicable
 			if ( in_array( $args['load_method'], $this->wp_enqueue_methods, true ) && empty( $args['loaded'] ) ) {
 				if ( function_exists( $wp_enqueue_function ) ) {
-					$wp_enqueue_function( $args['handle'], $args['src'], $args['deps'], $args['version'], $args['in_footer'] );
+					$wp_enqueue_function(
+						$args['handle'],
+						$args['src'],
+						$args['deps'],
+						$args['version'],
+						'style' === $args['type'] ? $args['media'] : $args['in_footer']
+					);
 					$args['loaded'] = true;
 				} else {
 					echo wp_kses_post( $this->format_error( $this->generate_asset_error( 'invalid_enqueue_function', false, $wp_enqueue_function ) ) );

--- a/tests/test-styles.php
+++ b/tests/test-styles.php
@@ -28,7 +28,7 @@ class Asset_Manager_Styles_Tests extends Asset_Manager_Test {
 			'src' => 'client/css/test.css',
 			'load_method' => 'preload',
 		];
-		$expected_style_output = '<link rel="preload" href="http://client/css/test.css" class="wp-asset-manager inline-preload-asset" media="" as="style" onload="this.rel=\'stylesheet\'"></link><noscript><link rel="stylesheet" href="http://client/css/test.css" class="wp-asset-manager inline-preload-asset" media=""></link></noscript>';
+		$expected_style_output = '<link rel="preload" href="http://client/css/test.css" class="wp-asset-manager inline-preload-asset" as="style" onload="this.rel=\'stylesheet\'" /><noscript><link rel="stylesheet" href="http://client/css/test.css" class="wp-asset-manager inline-preload-asset" /></noscript>';
 		$actual_style_output = get_echo( [ \Asset_Manager_Styles::instance(), 'print_asset' ], [ $preload_style ] );
 		$this->assertEquals( $expected_style_output, $actual_style_output, 'Should load CSS via a preload <link> tag that, on load, will switch to a stylesheet <link> tag' );
 
@@ -38,7 +38,7 @@ class Asset_Manager_Styles_Tests extends Asset_Manager_Test {
 			'src' => 'client/css/test.css',
 			'load_method' => 'async',
 		];
-		$expected_style_output = '<script class="wp-asset-manager inline-async-asset" type="text/javascript">loadCSS("http://client/css/test.css");</script><noscript><link rel="stylesheet" href="http://client/css/test.css" class="wp-asset-manager inline-async-asset" media=""></link></noscript>';
+		$expected_style_output = '<script class="wp-asset-manager inline-async-asset" type="text/javascript">loadCSS("http://client/css/test.css");</script><noscript><link rel="stylesheet" href="http://client/css/test.css" class="wp-asset-manager inline-async-asset" /></noscript>';
 		$actual_style_output = get_echo( [ \Asset_Manager_Styles::instance(), 'print_asset' ], [ $async_style ] );
 		$this->assertEquals( $expected_style_output, $actual_style_output, 'Should load CSS via loadCSS() function' );
 
@@ -48,7 +48,7 @@ class Asset_Manager_Styles_Tests extends Asset_Manager_Test {
 			'src' => 'client/css/test.css',
 			'load_method' => 'defer',
 		];
-		$expected_style_output = '<script class="wp-asset-manager inline-defer-asset" type="text/javascript">document.addEventListener("DOMContentLoaded",function(){loadCSS("http://client/css/test.css");});</script><noscript><link rel="stylesheet" href="http://client/css/test.css" class="wp-asset-manager inline-defer-asset" media=""></link></noscript>';
+		$expected_style_output = '<script class="wp-asset-manager inline-defer-asset" type="text/javascript">document.addEventListener("DOMContentLoaded",function(){loadCSS("http://client/css/test.css");});</script><noscript><link rel="stylesheet" href="http://client/css/test.css" class="wp-asset-manager inline-defer-asset" /></noscript>';
 		$actual_style_output = get_echo( [ \Asset_Manager_Styles::instance(), 'print_asset' ], [ $defer_style ] );
 		$this->assertEquals( $expected_style_output, $actual_style_output, 'Should load CSS via loadCSS() function called on DOMContentLoaded' );
 


### PR DESCRIPTION
# W3C Validation
The W3C validator complains if we:
- Use an empty media tag.
- Use a closing `<link>` tag.

# Aligning `wp_enqueue_`
`wp_enqueue_script()` has a different 5th argument than `wp_enqueue_style()` (`$in_footer` versus `$media`). 

# Adding in Travis
