### PR TITLE
`add_core_asset()`: `$in_footer` should default to array

### DIFF
--- a/php/class-asset-manager.php
+++ b/php/class-asset-manager.php
@@ -427,7 +427,7 @@ abstract class Asset_Manager {
 	public function add_core_asset( $handle, $load_method = 'sync' ) {
 		global ${$this->core_assets_global};
 		$core_assets_ref = ${$this->core_assets_global}->registered;
-		$in_footer = isset( ${$this->core_assets_global}->in_footer ) ? ${$this->core_assets_global}->in_footer : false;
+		$in_footer = isset( ${$this->core_assets_global}->in_footer ) ? ${$this->core_assets_global}->in_footer : array();
 		$core_asset_handles = array_keys( ${$this->core_assets_global}->registered );
 
 		// Add assets that are wp_enqueued_* for custom enqueues, but only if they're not also custom enqueued


### PR DESCRIPTION
I have a unit test in my theme which is failing because of an unexpected type:

```
in_array() expects parameter 2 to be array, bool given
/var/www/coolwebsite/wp-content/plugins/wp-asset-manager/php/class-asset-manager.php:437
```

It looks like `$in_footer` should default to an empty array.

---

Caused by the following:

I'm registering a style with `wp_register_style()` in my theme:

```php
	wp_register_style(
		'coolwebsite-google-fonts',
		'https://fonts.googleapis.com/css?family=Lora:400,400i,700,700i|Roboto+Condensed:400,700',
		[],
		'1.0'
	);
```

and specifying it as a dependency of another style which I'm loading with Asset Manager:

```php
	$styles = [
		[
			'condition'   => 'global',
			'deps'        => [ 'coolwebsite-google-fonts' ],
			'handle'      => 'coolwebsite-global-css',
			'load_hook'   => 'wp_head',
			'load_method' => 'sync',
			'src'         => '/path/to/src.css',
			'version'     => '1.0',
		],
	];
	array_map( [ \Asset_Manager_Styles::instance(), 'add_asset' ], $styles );
```

