### PR TITLE
Styles: Updates to Loading CSS Async

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,9 +24,9 @@ matrix:
       env: WP_VERSION=latest
     - php: 7.3
       env: WP_VERSION=latest
+  allow_failures:
     - php: 7.4
       env: WP_VERSION=nightly
-  allow_failures:
     - php: 7.3
       env: WP_TRAVISCI=phpcs
   fast_finish: true

--- a/php/class-asset-manager-styles.php
+++ b/php/class-asset-manager-styles.php
@@ -93,10 +93,10 @@ class Asset_Manager_Styles extends Asset_Manager {
 				}
 
 				if ( 'preload' === $stylesheet['load_method'] ) {
-					$print_string = '<link rel="preload" href="%1$s" class="%2$s" %3$s as="style" onload="this.rel=\'stylesheet\'" /><noscript><link rel="stylesheet" href="%1$s" class="%2$s" %3$s/></noscript>';
+					$print_string = '<link rel="preload" href="%1$s" class="%2$s" %3$s as="style" onload="this.onload=null;this.rel=\'stylesheet\'" /><noscript><link rel="stylesheet" href="%1$s" class="%2$s" %3$s/></noscript>';
 				} elseif ( 'async' === $stylesheet['load_method'] ) {
 					$onload_media = empty( $media ) ? 'all' : $media;
-					$print_string = '<link rel="stylesheet" class="%2$s" href="%1$s" media="print" onload="this.media=\'' . $onload_media . '\'" /><noscript><link rel="stylesheet" href="%1$s" %3$s class="%2$s" /></noscript>';
+					$print_string = '<link rel="stylesheet" class="%2$s" href="%1$s" media="print" onload="this.onload=null;this.media=\'' . $onload_media . '\'" /><noscript><link rel="stylesheet" href="%1$s" %3$s class="%2$s" /></noscript>';
 				} elseif ( 'defer' === $stylesheet['load_method'] ) {
 					$print_string = '<script class="%2$s" type="text/javascript">document.addEventListener("DOMContentLoaded",function(){loadCSS("%1$s");});</script><noscript><link rel="stylesheet" href="%1$s" class="%2$s" %3$s/></noscript>';
 				}

--- a/php/class-asset-manager-styles.php
+++ b/php/class-asset-manager-styles.php
@@ -95,7 +95,8 @@ class Asset_Manager_Styles extends Asset_Manager {
 				if ( 'preload' === $stylesheet['load_method'] ) {
 					$print_string = '<link rel="preload" href="%1$s" class="%2$s" %3$s as="style" onload="this.rel=\'stylesheet\'" /><noscript><link rel="stylesheet" href="%1$s" class="%2$s" %3$s/></noscript>';
 				} elseif ( 'async' === $stylesheet['load_method'] ) {
-					$print_string = '<script class="%2$s" type="text/javascript">loadCSS("%1$s");</script><noscript><link rel="stylesheet" href="%1$s" class="%2$s" %3$s/></noscript>';
+					$onload_media = empty( $media ) ? 'all' : $media;
+					$print_string = '<link rel="stylesheet" class="%2$s" href="%1$s" media="print" onload="this.media=\'' . $onload_media . '\'" /><noscript><link rel="stylesheet" href="%1$s" %3$s class="%2$s" /></noscript>';
 				} elseif ( 'defer' === $stylesheet['load_method'] ) {
 					$print_string = '<script class="%2$s" type="text/javascript">document.addEventListener("DOMContentLoaded",function(){loadCSS("%1$s");});</script><noscript><link rel="stylesheet" href="%1$s" class="%2$s" %3$s/></noscript>';
 				}

--- a/tests/test-assets.php
+++ b/tests/test-assets.php
@@ -281,7 +281,7 @@ class Asset_Manager_Core_Tests extends Asset_Manager_Test {
 				'loaded' => true,
 				'load_method' => 'sync',
 				'type' => 'script',
-				'version' => '1.12.4'
+				'version' => '1.12.4-wp'
 			],
 		];
 		$actual_assets = \Asset_Manager_Scripts::instance()->assets;

--- a/tests/test-styles.php
+++ b/tests/test-styles.php
@@ -28,7 +28,7 @@ class Asset_Manager_Styles_Tests extends Asset_Manager_Test {
 			'src' => 'client/css/test.css',
 			'load_method' => 'preload',
 		];
-		$expected_style_output = '<link rel="preload" href="http://client/css/test.css" class="wp-asset-manager inline-preload-asset" as="style" onload="this.rel=\'stylesheet\'" /><noscript><link rel="stylesheet" href="http://client/css/test.css" class="wp-asset-manager inline-preload-asset" /></noscript>';
+		$expected_style_output = '<link rel="preload" href="http://client/css/test.css" class="wp-asset-manager inline-preload-asset" as="style" onload="this.onload=null;this.rel=\'stylesheet\'" /><noscript><link rel="stylesheet" href="http://client/css/test.css" class="wp-asset-manager inline-preload-asset" /></noscript>';
 		$actual_style_output = get_echo( [ \Asset_Manager_Styles::instance(), 'print_asset' ], [ $preload_style ] );
 		$this->assertEquals( $expected_style_output, $actual_style_output, 'Should load CSS via a preload <link> tag that, on load, will switch to a stylesheet <link> tag' );
 
@@ -38,7 +38,7 @@ class Asset_Manager_Styles_Tests extends Asset_Manager_Test {
 			'src' => 'client/css/test.css',
 			'load_method' => 'async',
 		];
-		$expected_style_output = '<link rel="stylesheet" class="wp-asset-manager inline-async-asset" href="http://client/css/test.css" media="print" onload="this.media=\'all\'" /><noscript><link rel="stylesheet" href="http://client/css/test.css" class="wp-asset-manager inline-async-asset" /></noscript>';
+		$expected_style_output = '<link rel="stylesheet" class="wp-asset-manager inline-async-asset" href="http://client/css/test.css" media="print" onload="this.onload=null;this.media=\'all\'" /><noscript><link rel="stylesheet" href="http://client/css/test.css" class="wp-asset-manager inline-async-asset" /></noscript>';
 		$actual_style_output = get_echo( [ \Asset_Manager_Styles::instance(), 'print_asset' ], [ $async_style ] );
 		$this->assertEquals( $expected_style_output, $actual_style_output, 'Should load CSS via <link> tag that, on load, will switch to the media attribute from `print` to `all`' );
 
@@ -49,7 +49,7 @@ class Asset_Manager_Styles_Tests extends Asset_Manager_Test {
 			'load_method' => 'async',
 			'media' => 'screen and (min-width: 1200px)',
 		];
-		$expected_style_output = '<link rel="stylesheet" class="wp-asset-manager inline-async-asset" href="http://client/css/test.css" media="print" onload="this.media=\'screen and (min-width: 1200px)\'" /><noscript><link rel="stylesheet" href="http://client/css/test.css" media="screen and (min-width: 1200px)" class="wp-asset-manager inline-async-asset" /></noscript>';
+		$expected_style_output = '<link rel="stylesheet" class="wp-asset-manager inline-async-asset" href="http://client/css/test.css" media="print" onload="this.onload=null;this.media=\'screen and (min-width: 1200px)\'" /><noscript><link rel="stylesheet" href="http://client/css/test.css" media="screen and (min-width: 1200px)" class="wp-asset-manager inline-async-asset" /></noscript>';
 		$actual_style_output = get_echo( [ \Asset_Manager_Styles::instance(), 'print_asset' ], [ $async_media_style ] );
 		$this->assertEquals( $expected_style_output, $actual_style_output, 'Should load CSS via <link> tag that, on load, will switch to the media attribute from `print` to the media attribute value specified in the config' );
 

--- a/tests/test-styles.php
+++ b/tests/test-styles.php
@@ -38,9 +38,20 @@ class Asset_Manager_Styles_Tests extends Asset_Manager_Test {
 			'src' => 'client/css/test.css',
 			'load_method' => 'async',
 		];
-		$expected_style_output = '<script class="wp-asset-manager inline-async-asset" type="text/javascript">loadCSS("http://client/css/test.css");</script><noscript><link rel="stylesheet" href="http://client/css/test.css" class="wp-asset-manager inline-async-asset" /></noscript>';
+		$expected_style_output = '<link rel="stylesheet" class="wp-asset-manager inline-async-asset" href="http://client/css/test.css" media="print" onload="this.media=\'all\'" /><noscript><link rel="stylesheet" href="http://client/css/test.css" class="wp-asset-manager inline-async-asset" /></noscript>';
 		$actual_style_output = get_echo( [ \Asset_Manager_Styles::instance(), 'print_asset' ], [ $async_style ] );
-		$this->assertEquals( $expected_style_output, $actual_style_output, 'Should load CSS via loadCSS() function' );
+		$this->assertEquals( $expected_style_output, $actual_style_output, 'Should load CSS via <link> tag that, on load, will switch to the media attribute from `print` to `all`' );
+
+		// Async load with media method
+		$async_media_style = [
+			'handle' => 'inline-async-asset',
+			'src' => 'client/css/test.css',
+			'load_method' => 'async',
+			'media' => 'screen and (min-width: 1200px)',
+		];
+		$expected_style_output = '<link rel="stylesheet" class="wp-asset-manager inline-async-asset" href="http://client/css/test.css" media="print" onload="this.media=\'screen and (min-width: 1200px)\'" /><noscript><link rel="stylesheet" href="http://client/css/test.css" media="screen and (min-width: 1200px)" class="wp-asset-manager inline-async-asset" /></noscript>';
+		$actual_style_output = get_echo( [ \Asset_Manager_Styles::instance(), 'print_asset' ], [ $async_media_style ] );
+		$this->assertEquals( $expected_style_output, $actual_style_output, 'Should load CSS via <link> tag that, on load, will switch to the media attribute from `print` to the media attribute value specified in the config' );
 
 		// Defer load method
 		$defer_style = [


### PR DESCRIPTION
* Updates the method with which we async-load styles
    * Based on Filament Group's [The Simplest Way to Load CSS Asynchronously](https://www.filamentgroup.com/lab/load-css-simpler/)
* Nulls `onLoad` handlers as suggested in [Defer non-critical CSS](https://web.dev/defer-non-critical-css/#optimize)
    * > "nulling" the onload handler once it is used helps some browsers avoid re-calling the handler upon switching the rel attribute.