### PR TITLE
STORY-143 Register/Deregister Symbols

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,6 +378,22 @@ am_deregister_symbol( $handle = '' );
 >
 > Whether the symbol has been deregistered and removed from the sprite. `true` on success, or if the symbol hadn't been previously registered; `false` on failure.
 
+#### Replacing a symbol
+
+Prior to re-registering a symbol, verify the symbol to be replaced is removed.
+
+```php
+if ( am_deregister_symbol( 'logomark' ) ) {
+  am_register_symbol(
+    [
+      'handle'    => 'logomark',
+      'src'       => 'svg/logomark-alt.svg',
+      'condition' => 'global',
+    ]
+  );
+}
+```
+
 ### Displaying a Symbol
 
 `am_use_symbol` prints an `<svg>` element with the specified attributes.

--- a/README.md
+++ b/README.md
@@ -248,35 +248,40 @@ This function will also automatically add the `crossorigin` attribute for fonts,
 
 ## SVG Sprite
 
-Provides fine-grained control over displaying SVG assets in WordPress templates.
+Allows for fine-grained control over SVG assets in WordPress templates by creating a sprite of registered symbols and providing helper functions for displaying them.
 
 Asset Manager will add an SVG file's contents to the sprite if:
 
 1. The symbol is registered via `am_register_symbol` with a unique handle and valid file path
 2. The symbol's `condition` is truthy
 
-```html
-<svg style="display:none;" xmlns="http://www.w3.org/2000/svg">
-  <symbol
-    id="am-symbol-logomark"
-    viewBox="0 0 600 83"
-  >
-    <!-- ...coordinate data... -->
-  </symbol>
-</svg>
-```
-
 See [Conditions](#conditions) for more about Asset Manager's conditions and how to update them.
 
 ### Setup
 
-The sprite sheet is output via the [`wp_body_open`](https://developer.wordpress.org/reference/hooks/wp_body_open/) hook, so be sure your templates have the [wp_body_open()](https://developer.wordpress.org/reference/functions/wp_body_open/) function at the top of the document's `<body>` element.
+The sprite is printed via the [`wp_body_open`](https://developer.wordpress.org/reference/hooks/wp_body_open/) hook, so be sure your templates have the [wp_body_open()](https://developer.wordpress.org/reference/functions/wp_body_open/) function at the top of the document's `<body>` element.
+
+#### Admin pages
+
+Prints the sprite to admin pages via the `in_admin_header` hook, which is the most similar admin hook to `wp_body_open`. Symbols registered with condition(s) not matching admin pages will not be added to the sprite.
+
+```php
+/**
+ * Add SVG symbols to the admin page content.
+ */
+function print_admin_sprite() {
+  if ( class_exists( 'Asset_Manager_SVG_Sprite' ) ) {
+    Asset_Manager_SVG_Sprite::instance()->print_sprite_sheet();
+  }
+}
+add_action( 'in_admin_header', 'print_admin_sprite' );
+```
 
 ### Registering Symbols
 
-Use the `am_register_symbol` function to add a symbol to the sprite. Like `wp_register_script` and `wp_register_style`, an attempt to register an already registered symbol will be ignored.
+Use the `am_register_symbol` function to add a symbol to the sprite. Like `wp_register_script` and `wp_register_style`, an attempt to re-register a symbol with an existing handle will be ignored.
 
-This should be added via an action that fires before [`wp_body_open`](https://developer.wordpress.org/reference/hooks/wp_body_open/), such as `'init'`.
+**Symbols should be registered via an action that fires before [`wp_body_open`](https://developer.wordpress.org/reference/hooks/wp_body_open/).**
 
 ```php
 am_register_symbol(
@@ -288,33 +293,37 @@ am_register_symbol(
 );
 ```
 
+Options can be passed in as an array or individual parameters.
+
 **`$handle`**
 
 > `string`
 >
-> Handle for asset, used to refer to the symbol in `am_use_symbol`.
+> Handle for the asset. Should be unique.
 
 **`$src`** 
 
 > `string`
 >
-> Absolute path, or a relative path based on the current theme root, to the SVG file. Use the `am_modify_svg_directory` filter to update the directory from which relative paths will be completed.
+> Absolute path to the SVG file, or a relative path based on the current theme root. Use the `am_modify_svg_directory` filter to update the directory from which relative paths will be completed.
 
 **`$condition`** 
 
 > `string|array`
 >
-> Corresponds to a configured loading condition that, if matches, will allow the asset to be added to the sprite sheet.
+> Loading condition(s) that, when matched, will allow the asset to be added to the sprite.
 
 **`$attributes`** 
 
 > `array`
 >
-> An array of attribute names and values to add to the resulting `<svg>` everywhere it is printed.
+> An array of HTML attribute names and values to add to the resulting `<svg>` everywhere it is rendered.
 
-### Changing the directory
+### Changing the SVG directory
 
 Use the `am_modify_svg_directory` filter to update the directory from which relative paths will be completed.
+
+**Default**: The current theme root.
 
 ```php
 add_filter(
@@ -328,6 +337,8 @@ add_filter(
 ### Setting Global Attributes
 
 Use the `am_global_svg_attributes` filter to add global attributes that will apply to all symbols.
+
+**Default**: `[]`
 
 ```php
 add_filter(
@@ -343,7 +354,7 @@ add_filter(
 
 ### Update `$sprite_allowed_tags`
 
-Use the `am_sprite_allowed_tags` to filter [elements and attributes](php/svg-allowed-tags.php) used in escaping, such as certain deprecated attributes, script tags, and event handlers.
+Use the `am_sprite_allowed_tags` to filter [elements and attributes](php/svg-allowed-tags.php) used in escaping the sprite, such as certain deprecated attributes, script tags, and event handlers.
 
 ```php
 add_filter(
@@ -380,7 +391,7 @@ am_deregister_symbol( $handle = '' );
 
 #### Replacing a symbol
 
-Prior to re-registering a symbol, verify the symbol to be replaced is removed.
+Prior to re-registering a symbol, verify the symbol to be replaced is not registered.
 
 ```php
 if ( am_deregister_symbol( 'logomark' ) ) {
@@ -406,21 +417,17 @@ am_use_symbol( $handle = '', $attributes = [] );
 
 > `string`
 > 
-> The filename of the icon to display.
+> The handle with which the symbol was registered.
 
 **`$attributes`**
 
 > `array` 
 > 
-> An array of attribute-value pairs to add to the SVG markup.
+> An array of attribute-value pairs to add to the resulting SVG markup.
+> 
+> Override global attributes, or those defined via `am_register_symbol`, by declaring a new value here; remove it entirely by passing a falsy value.
 
-**Notes**
-
-_Attributes_
-
-💡 Override global attributes, or those defined via `am_register_symbol`, by passing a new value to `am_use_symbol`; remove it entirely by passing a falsy value.
-
-_SVG Sizing_ 
+#### Notes on SVG sizing
 
 Asset Manager will attempt to establish a default size for each SVG, which will be used to calculate the dimensions if only one, or neither, of `height` or `width` is passed to `am_use_symbol`.
 
@@ -431,7 +438,7 @@ The default size is based on (in order):
 
 If Asset Manager cannot determine a symbol's dimensions, both `height` _and_ `width` will need to be declared in the `attributes` array passed to `am_use_symbol`.
 
-💡 The simplest way to ensure SVGs are sized as expected is to verify each file's `<svg>` element has `height` and `width` attributes. 
+**The simplest way to ensure SVGs are sized as expected is to verify each file's `<svg>` element either has both `height` and `width` attributes or a viewBox attribute.**
 
 _**Example**_:
 

--- a/README.md
+++ b/README.md
@@ -356,21 +356,27 @@ add_filter(
 );
 ```
 
-### Replacing a Symbol
+### Removing a Symbol
 
-Use `am_replace_symbol` to replace a symbol already added to the sprite.
+Use `am_deregister_symbol` to remove a registered a symbol.
 
 This should be added via an action that fires after, or at a lower priority, than the action used for `am_register_symbol`.
 
 ```php
-am_replace_symbol(
-  [
-    'handle'    => 'logomark',
-    'src'       => 'svg/logo.svg',
-    'condition' => 'global',
-  ]
-);
+am_deregister_symbol( $handle = '' );
 ```
+
+**`$handle`**
+
+> `string`
+> 
+> The handle with which the symbol was registered.
+
+**Return**
+
+> `bool`
+>
+> Whether the symbol has been deregistered and removed from the sprite. `true` on success, or if the symbol hadn't been previously registered; `false` on failure.
 
 ### Displaying a Symbol
 

--- a/README.md
+++ b/README.md
@@ -252,7 +252,7 @@ Provides fine-grained control over displaying SVG assets in WordPress templates.
 
 Asset Manager will add an SVG file's contents to the sprite if:
 
-1. The symbol is registered via `am_define_symbol` with a valid file path
+1. The symbol is registered via `am_register_symbol` with a unique handle and valid file path
 2. The symbol's `condition` is truthy
 
 ```html
@@ -272,14 +272,14 @@ See [Conditions](#conditions) for more about Asset Manager's conditions and how 
 
 The sprite sheet is output via the [`wp_body_open`](https://developer.wordpress.org/reference/hooks/wp_body_open/) hook, so be sure your templates have the [wp_body_open()](https://developer.wordpress.org/reference/functions/wp_body_open/) function at the top of the document's `<body>` element.
 
-### Defining Symbols
+### Registering Symbols
 
-Use the `am_define_symbol` function to add a symbol to the sprite.
+Use the `am_register_symbol` function to add a symbol to the sprite. Like `wp_register_script` and `wp_register_style`, an attempt to register an already registered symbol will be ignored.
 
 This should be added via an action that fires before [`wp_body_open`](https://developer.wordpress.org/reference/hooks/wp_body_open/), such as `'init'`.
 
 ```php
-am_define_symbol(
+am_register_symbol(
   [
     'handle'    => 'logomark',
     'src'       => 'svg/logomark.svg',
@@ -360,7 +360,7 @@ add_filter(
 
 Use `am_replace_symbol` to replace a symbol already added to the sprite.
 
-This should be added via an action that fires after, or at a lower priority, than the action used for `am_define_symbol`.
+This should be added via an action that fires after, or at a lower priority, than the action used for `am_register_symbol`.
 
 ```php
 am_replace_symbol(
@@ -396,14 +396,14 @@ am_use_symbol( $handle = '', $attributes = [] );
 
 _Attributes_
 
-💡 Override global attributes, or those defined via `am_define_symbol`, by passing a new value to `am_use_symbol`; remove it entirely by passing a falsy value.
+💡 Override global attributes, or those defined via `am_register_symbol`, by passing a new value to `am_use_symbol`; remove it entirely by passing a falsy value.
 
 _SVG Sizing_ 
 
 Asset Manager will attempt to establish a default size for each SVG, which will be used to calculate the dimensions if only one, or neither, of `height` or `width` is passed to `am_use_symbol`.
 
 The default size is based on (in order):
-1. The values set in the symbol's `am_define_symbol` attributes array
+1. The values set in the symbol's `am_register_symbol` attributes array
 1. The `height` and `width` attributes from the SVG
 1. The `viewBox` attribute values
 

--- a/README.md
+++ b/README.md
@@ -354,7 +354,7 @@ add_filter(
 
 ### Update `$sprite_allowed_tags`
 
-Use the `am_sprite_allowed_tags` to filter [elements and attributes](php/svg-allowed-tags.php) used in escaping the sprite, such as certain deprecated attributes, script tags, and event handlers.
+Use the `am_sprite_allowed_tags` to filter [elements and attributes](php/kses-svg.php) used in escaping the sprite, such as certain deprecated attributes, script tags, and event handlers.
 
 ```php
 add_filter(

--- a/asset-manager.php
+++ b/asset-manager.php
@@ -164,26 +164,15 @@ if ( ! function_exists( 'am_register_symbol' ) ) :
 
 endif;
 
-if ( ! function_exists( 'am_replace_symbol' ) ) :
+if ( ! function_exists( 'am_deregister_symbol' ) ) :
 
 	/**
-	 * Replace a previously-defined symbol.
+	 * Remove a previously-registered symbol.
 	 *
-	 * @param string $handle     Handle for the asset to be replaced.
-	 * @param string $src        Absolute path from the current theme root, or a relative path
-	 *                           based on the current theme root. Use the `am_modify_svg_directory`
-	 *                           filter to update the directory from which relative paths will be
-	 *                           completed.
-	 * @param string $condition  Corresponds to a configured loading condition that, if matches,
-	 *                           will allow the asset to be added to the sprite sheet.
-	 *                           'global' is assumed if no condition is declared.
-	 * @param array  $attributes An array of attribute names and values to add to the resulting <svg>
-	 *                           everywhere it is printed.
+	 * @param string $handle Handle for the asset to be removed.
 	 */
-	function am_replace_symbol( $handle, $src = false, $condition = 'global', $attributes = [] ) {
-		$defaults = compact( 'handle', 'src', 'condition', 'attributes' );
-		$args     = is_array( $handle ) ? array_merge( $defaults, $handle ) : $defaults;
-		Asset_Manager_SVG_Sprite::instance()->replace_symbol( $args );
+	function am_deregister_symbol( $handle = '' ) {
+		return Asset_Manager_SVG_Sprite::instance()->remove_asset( $handle );
 	}
 
 endif;

--- a/asset-manager.php
+++ b/asset-manager.php
@@ -140,7 +140,7 @@ endif;
 
 add_action( 'after_setup_theme', [ 'Asset_Manager_Preload', 'instance' ], 10 );
 
-if ( ! function_exists( 'am_define_symbol' ) ) :
+if ( ! function_exists( 'am_register_symbol' ) ) :
 
 	/**
 	 * Define a symbol to be added to the SVG sprite.
@@ -156,7 +156,7 @@ if ( ! function_exists( 'am_define_symbol' ) ) :
 	 * @param array  $attributes An array of attribute names and values to add to the resulting <svg>
 	 *                           everywhere it is printed.
 	 */
-	function am_define_symbol( $handle, $src = false, $condition = 'global', $attributes = [] ) {
+	function am_register_symbol( $handle, $src = false, $condition = 'global', $attributes = [] ) {
 		$defaults = compact( 'handle', 'src', 'condition', 'attributes' );
 		$args     = is_array( $handle ) ? array_merge( $defaults, $handle ) : $defaults;
 		Asset_Manager_SVG_Sprite::instance()->add_asset( $args );

--- a/asset-manager.php
+++ b/asset-manager.php
@@ -172,7 +172,7 @@ if ( ! function_exists( 'am_deregister_symbol' ) ) :
 	 * @param string $handle Handle for the asset to be removed.
 	 */
 	function am_deregister_symbol( $handle = '' ) {
-		return Asset_Manager_SVG_Sprite::instance()->remove_asset( $handle );
+		return Asset_Manager_SVG_Sprite::instance()->remove_symbol( $handle );
 	}
 
 endif;

--- a/php/class-asset-manager-svg-sprite.php
+++ b/php/class-asset-manager-svg-sprite.php
@@ -107,7 +107,8 @@ class Asset_Manager_SVG_Sprite {
 			 * @param array $attributes {
 			 *     A list of attributes to be added to all SVG symbols.
 			 *
-			 *     @type array $attribute Attribute name-value pairs.
+			 *     @type array<string, string> The key represents an HTML attribute.
+			 *                                 The value represents attribute's value.
 			 * }
 			 */
 			static::$_global_attributes = apply_filters( 'am_global_svg_attributes', [] );
@@ -126,7 +127,7 @@ class Asset_Manager_SVG_Sprite {
 		$this->svg_allowed_tags = $am_svg_allowed_tags ?? [];
 
 		/**
-		 * Updates allowed inline style properties.
+		 * Ensures the sprite's `style` attribute isn't escaped.
 		 *
 		 * @param  string[] $styles Array of allowed CSS properties.
 		 * @return string[]         Modified safe inline style properties.

--- a/php/class-asset-manager-svg-sprite.php
+++ b/php/class-asset-manager-svg-sprite.php
@@ -419,7 +419,7 @@ class Asset_Manager_SVG_Sprite {
 	 * @param  array $handle The symbol handle.
 	 * @return bool Whether the symbol was removed, or wasn't registered.
 	 */
-	public function remove_asset( $handle ): bool {
+	public function remove_symbol( $handle ): bool {
 		if ( ! in_array( $handle, $this->asset_handles ) ) {
 			// Success: Handle not previously registered.
 			return true;

--- a/php/class-asset-manager-svg-sprite.php
+++ b/php/class-asset-manager-svg-sprite.php
@@ -54,6 +54,18 @@ class Asset_Manager_SVG_Sprite {
 	public $sprite_map = [];
 
 	/**
+	 * Allowed tags and attributes for echoing <svg> and <use> elements.
+	 *
+	 * @var array
+	 */
+	public $kses_svg_allowed_tags = [
+		'svg' => [],
+		'use' => [
+			'href' => true,
+		],
+	];
+
+	/**
 	 * Constructor.
 	 */
 	private function __construct() {
@@ -121,11 +133,6 @@ class Asset_Manager_SVG_Sprite {
 	 * Perform setup tasks.
 	 */
 	public function setup() {
-		// Allowed tags and attributes for SVG.
-		include __DIR__ . '/svg-allowed-tags.php';
-
-		$this->svg_allowed_tags = $am_svg_allowed_tags ?? [];
-
 		/**
 		 * Ensures the sprite's `style` attribute isn't escaped.
 		 *
@@ -159,18 +166,21 @@ class Asset_Manager_SVG_Sprite {
 	 * Prints the sprite sheet to the page at `wp_body_open`.
 	 */
 	public function print_sprite_sheet() {
+		// Allowed tags and attributes for SVG.
+		include __DIR__ . '/kses-svg.php';
+
 		/**
-		 * Filter function for patching in missing attributes and alements for escaping with `wp_kses`.
+		 * Filter function for patching in missing attributes and elements for escaping with `wp_kses`.
 		 *
 		 * @since 0.1.3
 		 *
 		 * @param array $am_svg_allowed_tags wp_kses allowed SVG for the sprite sheet.
 		 */
-		$sprite_allowed_tags = apply_filters( 'am_sprite_allowed_tags', $this->svg_allowed_tags );
+		$kses_sprite_allowed_tags = apply_filters( 'am_sprite_allowed_tags', $am_kses_svg ?? [] );
 
 		echo wp_kses(
 			$this->sprite_document->C14N(),
-			$sprite_allowed_tags
+			$kses_sprite_allowed_tags
 		);
 	}
 
@@ -205,13 +215,13 @@ class Asset_Manager_SVG_Sprite {
 	}
 
 	/**
-	 * Update allowed HTML.
+	 * Update allowed SVG.
 	 *
 	 * @param array $attributes Asset attributes.
 	 */
 	public function update_svg_allowed_tags( $attributes ) {
 		foreach ( array_keys( $attributes ) as $attr ) {
-			$this->svg_allowed_tags['svg'][ $attr ] = true;
+			$this->kses_svg_allowed_tags['svg'][ $attr ] = true;
 		}
 	}
 
@@ -513,7 +523,7 @@ class Asset_Manager_SVG_Sprite {
 		$symbol_markup = $this->get_symbol( $handle, $attrs );
 
 		if ( ! empty( $symbol_markup ) ) {
-			echo wp_kses( $symbol_markup, $this->svg_allowed_tags );
+			echo wp_kses( $symbol_markup, $this->kses_svg_allowed_tags );
 		}
 	}
 }

--- a/php/kses-svg.php
+++ b/php/kses-svg.php
@@ -240,7 +240,7 @@ $am_aria_attributes = [
  * SVG allowed tags and attributes.
  * Some elements accept specific attributes in addition to the categories of attributes.
  */
-$am_svg_allowed_tags = [
+$am_kses_svg = [
 	'a'                   => array_merge(
 		$am_animation_target_element_attributes,
 		$am_aria_attributes,

--- a/tests/test-sprite.php
+++ b/tests/test-sprite.php
@@ -194,8 +194,8 @@ class Asset_Manager_Sprite_Tests extends Asset_Manager_Test {
 
 		$this->assertArrayHasKey(
 			'focusable',
-			\Asset_Manager_SVG_Sprite::instance()->svg_allowed_tags['svg'],
-			'Should add global attributes to $svg_allowed_tags.'
+			\Asset_Manager_SVG_Sprite::instance()->kses_svg_allowed_tags['svg'],
+			'Should add global attributes to $kses_svg_allowed_tags.'
 		);
 
 		$with_attributes_markup_expected = '<svg focusable="false" aria-hidden="true" width="48" height="48" class="am-test" data-test="test"><use href="#am-symbol-with-dimensions"></use></svg>';
@@ -215,8 +215,8 @@ class Asset_Manager_Sprite_Tests extends Asset_Manager_Test {
 
 		$this->assertArrayHasKey(
 			'data-test',
-			\Asset_Manager_SVG_Sprite::instance()->svg_allowed_tags['svg'],
-			'Should add attributes to $svg_allowed_tags.'
+			\Asset_Manager_SVG_Sprite::instance()->kses_svg_allowed_tags['svg'],
+			'Should add attributes to $kses_svg_allowed_tags.'
 		);
 
 		$this->assertEquals(

--- a/tests/test-sprite.php
+++ b/tests/test-sprite.php
@@ -451,13 +451,13 @@ class Asset_Manager_Sprite_Tests extends Asset_Manager_Test {
 	 * Test replacing a symbol.
 	 */
 	function test_replace_symbol() {
-		$clean_with_dimensions = '<symbol id="am-symbol-replace-test" viewBox="0 0 24 24"><path d="M16 6l2.29 2.29-4.88 4.88-4-4L2 16.59 3.41 18l6-6 4 4 6.3-6.29L22 12V6z"></path><path d="M0 0h24v24H0z" fill="none"></path></symbol>';
+		$clean_with_dimensions = '<symbol id="am-symbol-deregister-test" viewBox="0 0 24 24"><path d="M16 6l2.29 2.29-4.88 4.88-4-4L2 16.59 3.41 18l6-6 4 4 6.3-6.29L22 12V6z"></path><path d="M0 0h24v24H0z" fill="none"></path></symbol>';
 
-		$with_export_junk = '<symbol id="am-symbol-replace-test" viewBox="0 0 24 24"><title>Export Junk</title><desc>Created with Sketch.</desc><path d="M16 6l2.29 2.29-4.88 4.88-4-4L2 16.59 3.41 18l6-6 4 4 6.3-6.29L22 12V6z"></path><path d="M0 0h24v24H0z" fill="none"></path></symbol>';
+		$with_export_junk = '<symbol id="am-symbol-deregister-test" viewBox="0 0 24 24"><title>Export Junk</title><desc>Created with Sketch.</desc><path d="M16 6l2.29 2.29-4.88 4.88-4-4L2 16.59 3.41 18l6-6 4 4 6.3-6.29L22 12V6z"></path><path d="M0 0h24v24H0z" fill="none"></path></symbol>';
 
 		am_register_symbol(
 			[
-				'handle'    => 'replace-test',
+				'handle'    => 'deregister-test',
 				'src'       => 'with-dimensions.svg',
 				'condition' => 'global',
 			]
@@ -474,24 +474,24 @@ class Asset_Manager_Sprite_Tests extends Asset_Manager_Test {
 			'Should add the symbol to the sprite sheet.'
 		);
 
-		// Redefined with the same handle.
-		am_replace_symbol(
-			[
-				'handle'    => 'replace-test',
-				'src'       => 'export-junk.svg',
-				'condition' => 'global',
-			]
-		);
+		// Remove.
+		$symbol_was_removed = am_deregister_symbol( 'deregister-test' );
 
-		$with_replaced_symbol = sprintf(
+		$with_removed_symbol = sprintf(
 			$this->empty_sprite_wrapper,
-			$with_export_junk
+			''
 		);
 
 		$this->assertEquals(
-			$with_replaced_symbol,
+			$with_removed_symbol,
 			\Asset_Manager_SVG_Sprite::instance()->sprite_document->C14N(),
-			'Should replace the existing symbol in the sprite sheet.'
+			'Should remove the symbol from the sprite sheet.'
 		);
+
+		$this->assertTrue( $symbol_was_removed );
+
+		// Returns true if the symbol hasn't been registered.
+		$symbol_not_exist = am_deregister_symbol( 'nonexistent' );
+		$this->assertTrue( $symbol_not_exist );
 	}
 }

--- a/tests/test-sprite.php
+++ b/tests/test-sprite.php
@@ -48,7 +48,7 @@ class Asset_Manager_Sprite_Tests extends Asset_Manager_Test {
 			'Should create an empty sprite sheet.'
 		);
 
-		am_define_symbol(
+		am_register_symbol(
 			[
 				'handle'     => 'no-dimensions',
 				'src'        => 'no-dimensions.svg',
@@ -56,7 +56,7 @@ class Asset_Manager_Sprite_Tests extends Asset_Manager_Test {
 			]
 		);
 
-		am_define_symbol(
+		am_register_symbol(
 			[
 				'handle'    => 'with-dimensions',
 				'src'       => 'with-dimensions.svg',
@@ -64,7 +64,7 @@ class Asset_Manager_Sprite_Tests extends Asset_Manager_Test {
 			]
 		);
 
-		am_define_symbol(
+		am_register_symbol(
 			[
 				'handle'    => 'export-junk',
 				'src'       => 'export-junk.svg',
@@ -95,7 +95,7 @@ class Asset_Manager_Sprite_Tests extends Asset_Manager_Test {
 	 */
 	function test_add_asset_no_dimensions() {
 
-		am_define_symbol(
+		am_register_symbol(
 			[
 				'handle'     => 'no-dimensions',
 				'src'        => 'no-dimensions.svg',
@@ -143,7 +143,7 @@ class Asset_Manager_Sprite_Tests extends Asset_Manager_Test {
 				'no-dimensions',
 				[
 					'height'      => 48,
-					// Overrides attributes passed to `am_define_symbol()`.
+					// Overrides attributes passed to `am_register_symbol()`.
 					'id'          => null,
 					'data-test'   => 'test',
 					// Override global attribute
@@ -159,7 +159,7 @@ class Asset_Manager_Sprite_Tests extends Asset_Manager_Test {
 	 */
 	function test_with_dimensions() {
 
-		am_define_symbol(
+		am_register_symbol(
 			[
 				'handle'    => 'with-dimensions',
 				'src'       => 'with-dimensions.svg',
@@ -241,7 +241,7 @@ class Asset_Manager_Sprite_Tests extends Asset_Manager_Test {
 	 */
 	function test_asset_with_export_junk() {
 
-		am_define_symbol(
+		am_register_symbol(
 			[
 				'handle'    => 'export-junk',
 				'src'       => 'export-junk.svg',
@@ -272,7 +272,7 @@ class Asset_Manager_Sprite_Tests extends Asset_Manager_Test {
 	 */
 	function test_asset_with_embedded_script() {
 
-		am_define_symbol(
+		am_register_symbol(
 			[
 				'handle'    => 'embedded-script',
 				'src'       => 'danger.svg',
@@ -297,7 +297,7 @@ class Asset_Manager_Sprite_Tests extends Asset_Manager_Test {
 	 */
 	function test_asset_with_defined_dimensions() {
 
-		am_define_symbol(
+		am_register_symbol(
 			[
 				'handle'     => 'no-dimensions',
 				'src'        => 'no-dimensions.svg',
@@ -330,7 +330,7 @@ class Asset_Manager_Sprite_Tests extends Asset_Manager_Test {
 	 * Test adding an asset with nested elements.
 	 */
 	function test_asset_with_nested_dom() {
-		am_define_symbol(
+		am_register_symbol(
 			[
 				'handle'    => 'nested',
 				'src'       => 'nested.svg',
@@ -361,7 +361,7 @@ class Asset_Manager_Sprite_Tests extends Asset_Manager_Test {
 	 */
 	function test_escape_non_standard_attributes() {
 
-		am_define_symbol(
+		am_register_symbol(
 			[
 				'handle'    => 'without-non-standard-attribute',
 				'src'       => 'non-standard-attribute.svg',
@@ -388,7 +388,7 @@ class Asset_Manager_Sprite_Tests extends Asset_Manager_Test {
 	 */
 	function test_allow_non_standard_attribute() {
 
-		am_define_symbol(
+		am_register_symbol(
 			[
 				'handle'    => 'with-non-standard-attribute',
 				'src'       => 'non-standard-attribute.svg',
@@ -424,7 +424,7 @@ class Asset_Manager_Sprite_Tests extends Asset_Manager_Test {
 	 */
 	function test_escape_camelcase_tags_and_attributes() {
 
-		am_define_symbol(
+		am_register_symbol(
 			[
 				'handle'    => 'without-camelcase-tags-and-attrs',
 				'src'       => 'camelcase.svg',
@@ -455,7 +455,7 @@ class Asset_Manager_Sprite_Tests extends Asset_Manager_Test {
 
 		$with_export_junk = '<symbol id="am-symbol-replace-test" viewBox="0 0 24 24"><title>Export Junk</title><desc>Created with Sketch.</desc><path d="M16 6l2.29 2.29-4.88 4.88-4-4L2 16.59 3.41 18l6-6 4 4 6.3-6.29L22 12V6z"></path><path d="M0 0h24v24H0z" fill="none"></path></symbol>';
 
-		am_define_symbol(
+		am_register_symbol(
 			[
 				'handle'    => 'replace-test',
 				'src'       => 'with-dimensions.svg',


### PR DESCRIPTION
- Renames `am_define_symbol` as `am_register_symbol`
- Removes `am_replace_symbol`
- Adds `am_deregister_symbol`
- Separates escaping concerns between the sprite and the `am_use_symbol` output
- Updates documentation