### PR TITLE
Uses `file_get_contents` exclusively

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,13 @@
 # Change Log
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## 1.1.0
+## 1.1.2
+
+* Updates the requirements on `mantle-framework/testkit` to permit the latest version (#36)
+* Addresses PHP 8 compatibility issue with the global usage in `Asset_Manager::add_core_asset()` (#37)
+* Fixes a bug where `get_svg()` returns false for local files on WP VIP environments (#39)
+
+## 1.1.1
 
 Adds support for registering SVG assets to be added to a template's sprite sheet, with methods for displaying those assets
 

--- a/asset-manager.php
+++ b/asset-manager.php
@@ -10,7 +10,7 @@ Plugin Name: Asset Manager
 Plugin URI: https://github.com/alleyinteractive/wp-asset-manager
 Description: Add more robust functionality to enqueuing static assets
 Author: Alley Interactive
-Version: 1.1.0
+Version: 1.1.2
 License: GPLv2 or later
 Author URI: https://www.alleyinteractive.com/
 */

--- a/php/class-asset-manager-svg-sprite.php
+++ b/php/class-asset-manager-svg-sprite.php
@@ -249,9 +249,7 @@ class Asset_Manager_SVG_Sprite {
 		}
 
 		if ( file_exists( $path ) && 0 === validate_file( $path ) ) {
-			$file_contents = function_exists( 'wpcom_vip_file_get_contents' )
-				? wpcom_vip_file_get_contents( $path )
-				: file_get_contents( $path ); // phpcs:ignore WordPressVIPMinimum.Performance.FetchingRemoteData.FileGetContentsUnknown
+			$file_contents = file_get_contents( $path ); // phpcs:ignore WordPressVIPMinimum.Performance.FetchingRemoteData.FileGetContentsUnknown
 
 			if ( ! empty( $file_contents ) ) {
 				$doc = new DOMDocument();


### PR DESCRIPTION
This fixes a bug where `wpcom_vip_file_get_contents` returns false for local files.