### PR TITLE
Uses `file_get_contents` exclusively

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change Log
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## Next
+
+* Fixes a bug where `print_asset()` fails for local files on WP VIP environments (#40)
+
 ## 1.1.2
 
 * Updates the requirements on `mantle-framework/testkit` to permit the latest version (#36)

--- a/php/class-asset-manager-scripts.php
+++ b/php/class-asset-manager-scripts.php
@@ -188,9 +188,7 @@ class Asset_Manager_Scripts extends Asset_Manager {
 						wp_json_encode( $script['src'] )
 					);
 				} elseif ( 0 === validate_file( $script['src'] ) && file_exists( $script['src'] ) ) {
-					$file_contents = function_exists( 'wpcom_vip_file_get_contents' )
-						? wpcom_vip_file_get_contents( $script['src'] )
-						: file_get_contents( $script['src'] ); // phpcs:ignore WordPressVIPMinimum.Performance.FetchingRemoteData.FileGetContentsUnknown
+					$file_contents = file_get_contents( $script['src'] ); // phpcs:ignore WordPressVIPMinimum.Performance.FetchingRemoteData.FileGetContentsUnknown
 
 					printf(
 						'<script class="%1$s" type="text/javascript">%2$s</script>',


### PR DESCRIPTION
The `wpcom_vip_file_get_contents` function is specifically for remote files and fails for local files. This was previously fixed for SVGs via a398cc952, but apparently I somehow missed that it was used here as well.