### PR TITLE
Filters allowed svg+use tags & attributes globally

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 * Fixes a bug where `print_asset()` fails for local files on WP VIP environments (#40)
 * Adds `am_symbol_is_registered` for determining if a symbol is registered (#41)
+* Filters allowed svg+use tags & attributes globally (#43)
 
 ## 1.1.2
 

--- a/php/class-asset-manager-svg-sprite.php
+++ b/php/class-asset-manager-svg-sprite.php
@@ -146,6 +146,8 @@ class Asset_Manager_SVG_Sprite {
 				return $styles;
 			}
 		);
+
+		add_filter( 'wp_kses_allowed_html', [ $this, 'extend_kses_post_with_use_svg' ] );
 	}
 
 	/**
@@ -448,6 +450,17 @@ class Asset_Manager_SVG_Sprite {
 	}
 
 	/**
+	 * Filter allowed HTML to allow svg & use tags and attributes.
+	 *
+	 * @param array $allowed Allowed tags, attributes, and/or entities.
+	 * @return array filtered tags.
+	 */
+	public function extend_kses_post_with_use_svg( $allowed ) {
+		$use_svg_tags = $this->kses_svg_allowed_tags;
+		return array_merge_recursive( $allowed, $use_svg_tags );
+	}
+
+	/**
 	 * Returns the SVG markup for displaying a symbol.
 	 *
 	 * @param  string $handle The symbol handle.
@@ -521,7 +534,7 @@ class Asset_Manager_SVG_Sprite {
 		$symbol_markup = $this->get_symbol( $handle, $attrs );
 
 		if ( ! empty( $symbol_markup ) ) {
-			echo wp_kses( $symbol_markup, $this->kses_svg_allowed_tags );
+			echo wp_kses_post( $symbol_markup );
 		}
 	}
 }

--- a/tests/test-sprite.php
+++ b/tests/test-sprite.php
@@ -137,20 +137,28 @@ class Asset_Manager_Sprite_Tests extends Asset_Manager_Test {
 
 		$with_attributes_markup_expected = '<svg data-test="test" width="48" height="48"><use href="#am-symbol-no-dimensions"></use></svg>';
 
+		$with_attributes_markup_actual = am_get_symbol(
+			'no-dimensions',
+			[
+				'height'      => 48,
+				// Overrides attributes passed to `am_register_symbol()`.
+				'id'          => null,
+				'data-test'   => 'test',
+				// Override global attribute
+				'aria-hidden' => false,
+			]
+		);
+
 		$this->assertEquals(
 			$with_attributes_markup_expected,
-			am_get_symbol(
-				'no-dimensions',
-				[
-					'height'      => 48,
-					// Overrides attributes passed to `am_register_symbol()`.
-					'id'          => null,
-					'data-test'   => 'test',
-					// Override global attribute
-					'aria-hidden' => false,
-				]
-			),
+			$with_attributes_markup_actual,
 			'Should get the svg + use markup, with calculated height, global attributes, and additional attributes.'
+		);
+
+		$this->assertEquals(
+			$with_attributes_markup_expected,
+			wp_kses_post( $with_attributes_markup_actual ),
+			'Should properly escape the svg + use markup and attributes.'
 		);
 	}
 
@@ -318,11 +326,18 @@ class Asset_Manager_Sprite_Tests extends Asset_Manager_Test {
 		);
 
 		$with_height_expected = '<svg focusable="false" aria-hidden="true" width="12" height="12"><use href="#am-symbol-no-dimensions"></use></svg>';
+		$with_height_actual   = am_get_symbol( 'no-dimensions', [ 'height' => '12' ] );
 
 		$this->assertEquals(
 			$with_height_expected,
-			am_get_symbol( 'no-dimensions', [ 'height' => '12' ] ),
+			$with_height_actual,
 			'Should get the svg + use markup with the dimensions calculated from defined dimensions.'
+		);
+
+		$this->assertEquals(
+			$with_height_expected,
+			wp_kses_post( $with_height_actual ),
+			'Should properly escape the svg + use markup.'
 		);
 	}
 


### PR DESCRIPTION
I found that including the `am_get_symbol` return value in filtered markup wasn't escaped properly, resulting in the SVG not appearing. I worked around it by filtering `wp_kses` in the theme. This move that code into the plugin where it belongs.