### PR TITLE
Use custom meta capability to restrict displaying errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Change Log
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 1.3.0
+
+**Changed**
+
+* Use `am_view_asset_error` meta capability -- mapped to `manage_options` by default -- to determine whether to display errors messages related to asset enqueuing.
+
 ## 1.2.0
 
 **Added**

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 **Changed**
 
-* Use `am_view_asset_error` meta capability -- mapped to `manage_options` by default -- to determine whether to display errors messages related to asset enqueuing.
+* Use `am_view_asset_error` meta capability to determine whether to display errors messages related to asset enqueuing. `am_view_asset_error` is mapped to `manage_options` by default.
 
 ## 1.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 **Changed**
 
-* Use `am_view_asset_error` meta capability to determine whether to display errors messages related to asset enqueuing. `am_view_asset_error` is mapped to `manage_options` by default.
+* Use `am_view_asset_error` meta capability to determine whether to display error messages related to asset enqueuing. `am_view_asset_error` is mapped to `manage_options` by default.
 
 ## 1.2.0
 

--- a/asset-manager.php
+++ b/asset-manager.php
@@ -224,3 +224,25 @@ if ( ! function_exists( 'am_symbol_is_registered' ) ) :
 endif;
 
 add_action( 'after_setup_theme', [ 'Asset_Manager_SVG_Sprite', 'instance' ], 10 );
+
+if ( ! function_exists( 'am_map_meta_caps' ) ) :
+
+	/**
+	 * Map plugin meta capabilities.
+	 *
+	 * @param string[] $caps Primitive capabilities required of the user.
+	 * @param string   $cap  Capability being checked.
+	 * @return string[] Updated primitive capabilities.
+	 */
+	function am_map_meta_caps( $caps, $cap ) {
+		// By default, require the 'manage_options' capability to view asset errors.
+		if ( 'am_view_asset_error' === $cap ) {
+			$caps = [ 'manage_options' ];
+		}
+
+		return $caps;
+	}
+
+endif;
+
+add_filter( 'map_meta_cap', 'am_map_meta_caps', 10, 2 );

--- a/php/traits/trait-asset-error.php
+++ b/php/traits/trait-asset-error.php
@@ -70,16 +70,7 @@ trait Asset_Error {
 	 * @param WP_Error $error Error to display to user.
 	 */
 	public function format_error( $error ) {
-		$show_error = current_user_can( 'manage_options' );
-
-		/**
-		 * Filter whether to show errors to the user.
-		 *
-		 * @param $show_error bool     Whether to show errors to the user.
-		 * @param $error      WP_Error The error to display to the user.
-		 */
-		$show_error = apply_filters( 'am_show_enqueue_error', $show_error, $error );
-		if ( $show_error ) {
+		if ( current_user_can( 'manage_options' ) ) {
 			$code = $error->get_error_code();
 			echo wp_kses(
 				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_print_r

--- a/php/traits/trait-asset-error.php
+++ b/php/traits/trait-asset-error.php
@@ -70,7 +70,7 @@ trait Asset_Error {
 	 * @param WP_Error $error Error to display to user.
 	 */
 	public function format_error( $error ) {
-		if ( current_user_can( 'manage_options' ) ) {
+		if ( current_user_can( 'am_view_asset_error', $error ) ) {
 			$code = $error->get_error_code();
 			echo wp_kses(
 				// phpcs:ignore WordPress.PHP.DevelopmentFunctions.error_log_print_r


### PR DESCRIPTION
The `am_show_enqueue_error` filter meets a real-world need. But it seems to me that the filter itself is somewhat repetitive of the filters that WordPress core makes available in the `current_user_can()` call just above it.

This PR proposes controlling the error display instead with a custom meta capability. That capability will be mapped by default to `manage_options`, preserving backwards compatibility. Developers can use the core `map_meta_cap` and `user_has_cap` filters to further customize who sees asset errors.

For example, here's a snippet (slightly modified) illustrating how `map_meta_cap` could be used with the new meta capability to address a problem that one of our clients recently faced:

```php
add_filter(
	'map_meta_cap',
	function ( $caps, $cap, $user_id ) {
		if ( 'am_view_asset_error' !== $cap ) {
			return $caps;
		}

		if ( 'local' === wp_get_environment_type() ) {
			// No caps required to view errors in local environment.
			return [];
		}

		$user = get_userdata( $user_id );

		if ( $user && str_contains( $user->user_email, '@example.com' ) ) {
			// Users from this company who can manage options can view.
			return [ 'manage_options' ];
		}

		// No one else allowed to view.
		return [ 'do_not_allow' ];
	},
	11,
	3,
);
```