### PR TITLE
Changes the method with which we hide the sprite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Change Log
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 1.3.2
+
+**Changed**
+
+* The SVG Sprite is no longer hidden with `display:none` and instead visually hidden and moved offscreen (#49)
+
 ## 1.3.1
 
 * Check for array key before using when preloading assets (#47).

--- a/asset-manager.php
+++ b/asset-manager.php
@@ -10,7 +10,7 @@ Plugin Name: Asset Manager
 Plugin URI: https://github.com/alleyinteractive/wp-asset-manager
 Description: Add more robust functionality to enqueuing static assets
 Author: Alley Interactive
-Version: 1.2.0
+Version: 1.3.2
 License: GPLv2 or later
 Author URI: https://www.alleyinteractive.com/
 */

--- a/php/class-asset-manager-svg-sprite.php
+++ b/php/class-asset-manager-svg-sprite.php
@@ -142,7 +142,10 @@ class Asset_Manager_SVG_Sprite {
 		add_filter(
 			'safe_style_css',
 			function( $styles ) {
-				$styles[] = 'display';
+				$styles[] = 'left';
+				$styles[] = 'overflow';
+				$styles[] = 'position';
+				$styles[] = 'visibility';
 				return $styles;
 			}
 		);
@@ -157,7 +160,14 @@ class Asset_Manager_SVG_Sprite {
 		$this->sprite_document = new DOMDocument();
 
 		$this->svg_root = $this->sprite_document->createElementNS( 'http://www.w3.org/2000/svg', 'svg' );
-		$this->svg_root->setAttribute( 'style', 'display:none' );
+
+		$this->svg_root->setAttribute( 'style', 'left:-9999px;overflow:hidden;position:absolute;visibility:hidden' );
+
+		$this->svg_root->setAttribute( 'focusable', 'false' );
+		$this->svg_root->setAttribute( 'height', '0' );
+		$this->svg_root->setAttribute( 'role', 'none' );
+		$this->svg_root->setAttribute( 'viewBox', '0 0 0 0' );
+		$this->svg_root->setAttribute( 'width', '0' );
 
 		$this->sprite_document->appendChild( $this->svg_root );
 

--- a/php/kses-svg.php
+++ b/php/kses-svg.php
@@ -867,6 +867,7 @@ $am_kses_svg = [
 	),
 	'svg'                 => array_merge(
 		[
+			'focusable'           => true,
 			'height'              => true,
 			'preserveaspectratio' => true,
 			'viewbox'             => true,

--- a/tests/test-sprite.php
+++ b/tests/test-sprite.php
@@ -4,7 +4,7 @@ namespace Asset_Manager_Tests;
 
 class Asset_Manager_Sprite_Tests extends Asset_Manager_Test {
 
-	public $empty_sprite_wrapper = '<svg xmlns="http://www.w3.org/2000/svg" style="display:none">%s</svg>';
+	public $empty_sprite_wrapper = '<svg xmlns="http://www.w3.org/2000/svg" focusable="false" height="0" role="none" style="left:-9999px;overflow:hidden;position:absolute;visibility:hidden" viewBox="0 0 0 0" width="0">%s</svg>';
 
 	/**
 	 * Note: These aren't stright copies of SVG contents; they have been modified


### PR DESCRIPTION
I recently hit an issue with an SVG file that wasn't rendering correctly because it contains a `url()` function pointing to a linearGradient element. I found that hiding the sprite sheet with `display:none` was the culprit. I've changed the way we hide the sprite sheet to match the way WP core handles them.