### PR TITLE
[SVG Sprite] Removes `visibility:hidden` and let off-screen positioning hide the sprite

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## 1.3.3
 
 * Removes `visibility:hidden` SVG sprite style declaration, which breaks some SVG element references (#50)
-* Upgrades to `mantle-framework/testkit` v0.11.1 (#50)
+* Upgrades to `mantle-framework/testkit` v0.11 (#50)
 
 ## 1.3.2
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Change Log
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 1.3.3
+
+* Removes `visibility:hidden` SVG sprite style declaration, which breaks some SVG element references (#50)
+* Upgrades to `mantle-framework/testkit` v0.11.1 (#50)
+
 ## 1.3.2
 
 **Changed**

--- a/asset-manager.php
+++ b/asset-manager.php
@@ -10,7 +10,7 @@ Plugin Name: Asset Manager
 Plugin URI: https://github.com/alleyinteractive/wp-asset-manager
 Description: Add more robust functionality to enqueuing static assets
 Author: Alley Interactive
-Version: 1.3.2
+Version: 1.3.3
 License: GPLv2 or later
 Author URI: https://www.alleyinteractive.com/
 */

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require-dev": {
         "alleyinteractive/alley-coding-standards": "^1.0",
-        "mantle-framework/testkit": "^0.10",
+        "mantle-framework/testkit": "0.11.1",
         "phpunit/phpunit": "^9.3.3"
     },
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require-dev": {
         "alleyinteractive/alley-coding-standards": "^1.0",
-        "mantle-framework/testkit": "0.11.1",
+        "mantle-framework/testkit": "^0.11",
         "phpunit/phpunit": "^9.3.3"
     },
     "autoload": {

--- a/php/class-asset-manager-svg-sprite.php
+++ b/php/class-asset-manager-svg-sprite.php
@@ -145,7 +145,6 @@ class Asset_Manager_SVG_Sprite {
 				$styles[] = 'left';
 				$styles[] = 'overflow';
 				$styles[] = 'position';
-				$styles[] = 'visibility';
 				return $styles;
 			}
 		);
@@ -161,7 +160,7 @@ class Asset_Manager_SVG_Sprite {
 
 		$this->svg_root = $this->sprite_document->createElementNS( 'http://www.w3.org/2000/svg', 'svg' );
 
-		$this->svg_root->setAttribute( 'style', 'left:-9999px;overflow:hidden;position:absolute;visibility:hidden' );
+		$this->svg_root->setAttribute( 'style', 'left:-9999px;overflow:hidden;position:absolute' );
 
 		$this->svg_root->setAttribute( 'focusable', 'false' );
 		$this->svg_root->setAttribute( 'height', '0' );

--- a/tests/test-sprite.php
+++ b/tests/test-sprite.php
@@ -4,7 +4,7 @@ namespace Asset_Manager_Tests;
 
 class Asset_Manager_Sprite_Tests extends Asset_Manager_Test {
 
-	public $empty_sprite_wrapper = '<svg xmlns="http://www.w3.org/2000/svg" focusable="false" height="0" role="none" style="left:-9999px;overflow:hidden;position:absolute;visibility:hidden" viewBox="0 0 0 0" width="0">%s</svg>';
+	public $empty_sprite_wrapper = '<svg xmlns="http://www.w3.org/2000/svg" focusable="false" height="0" role="none" style="left:-9999px;overflow:hidden;position:absolute" viewBox="0 0 0 0" width="0">%s</svg>';
 
 	/**
 	 * Note: These aren't stright copies of SVG contents; they have been modified


### PR DESCRIPTION
In #49 we updated the way we hide the SVG sprite to fix rendering issues. I've found that `visibility: hidden` causes rendering issues when an SVG references another element, such as `clipPath`, by ID. The recommendation is to position the sprite offscreen, which we're already doing, without any additional hiding.

I've included an update to `mantle-framework/testkit` to clean up the PHPUnit output.