### PR TITLE
Add support for Windows filepaths

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
+.idea
 .vscode
 tests/php/build
 tests/php/wp-unit-test

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change Log
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 1.3.6
+
+* Adds support for running the plugin on a Windows hosting environment (#57)
+
 ## 1.3.5
 
 * Removes default kses allowed SVG attributes

--- a/asset-manager.php
+++ b/asset-manager.php
@@ -10,7 +10,7 @@ Plugin Name: Asset Manager
 Plugin URI: https://github.com/alleyinteractive/wp-asset-manager
 Description: Add more robust functionality to enqueuing static assets
 Author: Alley Interactive
-Version: 1.3.3
+Version: 1.3.6
 License: GPLv2 or later
 Author URI: https://www.alleyinteractive.com/
 */
@@ -19,6 +19,19 @@ Author URI: https://www.alleyinteractive.com/
  * Filesystem path to AssetManager.
  */
 defined( 'AM_BASE_DIR' ) || define( 'AM_BASE_DIR', dirname( __FILE__ ) );
+
+if ( ! function_exists( 'am_validate_path' ) ) {
+	/**
+	 * Helper function to validate a path before doing something with it.
+	 *
+	 * @param string $path The path to validate.
+	 *
+	 * @return bool True if the path is valid, false otherwise.
+	 */
+	function am_validate_path( string $path ) : bool {
+		return in_array( validate_file( $path ), [ 0, 2 ], true ) && file_exists( $path );
+	}
+}
 
 if ( ! class_exists( 'Asset_Manager' ) ) :
 	/**

--- a/php/class-asset-manager-scripts.php
+++ b/php/class-asset-manager-scripts.php
@@ -187,7 +187,7 @@ class Asset_Manager_Scripts extends Asset_Manager {
 						esc_js( $script['handle'] ),
 						wp_json_encode( $script['src'] )
 					);
-				} elseif ( 0 === validate_file( $script['src'] ) && file_exists( $script['src'] ) ) {
+				} elseif ( am_validate_path( $script['src'] ) ) {
 					$file_contents = file_get_contents( $script['src'] ); // phpcs:ignore WordPressVIPMinimum.Performance.FetchingRemoteData.FileGetContentsUnknown
 
 					printf(

--- a/php/class-asset-manager-styles.php
+++ b/php/class-asset-manager-styles.php
@@ -81,7 +81,7 @@ class Asset_Manager_Styles extends Asset_Manager {
 		if ( ! empty( $stylesheet['src'] ) && ! in_array( $stylesheet['load_method'], $this->wp_enqueue_methods, true ) ) {
 			if ( 'inline' === $stylesheet['load_method'] ) {
 				// Validate inline styles.
-				if ( 0 === validate_file( $stylesheet['src'] ) && file_exists( $stylesheet['src'] ) ) {
+				if ( am_validate_path( $stylesheet['src'] ) ) {
 					printf(
 						'<style class="%1$s" type="text/css">%2$s</style>',
 						esc_attr( implode( ' ', $classes ) ),

--- a/php/class-asset-manager-svg-sprite.php
+++ b/php/class-asset-manager-svg-sprite.php
@@ -266,7 +266,7 @@ class Asset_Manager_SVG_Sprite {
 			return '';
 		}
 
-		if ( file_exists( $path ) && 0 === validate_file( $path ) ) {
+		if ( am_validate_path( $path ) ) {
 			$file_contents = file_get_contents( $path ); // phpcs:ignore WordPressVIPMinimum.Performance.FetchingRemoteData.FileGetContentsUnknown
 
 			if ( ! empty( $file_contents ) ) {


### PR DESCRIPTION
- Adds support for Windows filepaths by accepting both `0` and `2` as valid return values from `validate_file` (a return value of `2` means that the path is a Windows filepath, which is normal and expected on a Windows system).
- Abstracts the process of validating files for inclusion to a generic function.

Fixes #57 