### PR TITLE
Fix: `Asset_Manager_Preload::set_asset_types()` should return an empty `array` if no valid arguments are passed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,11 @@
 # Change Log
 This project adheres to [Semantic Versioning](http://semver.org/).
 
+## 1.3.8 (unreleased)
+
+* Fix: `Asset_Manager_Preload::set_asset_types()` should return an empty array if no valid arguments are passed.
+* Add: Add `convertDeprecationsToExceptions` to `phpunit.xml`.
+
 ## 1.3.7
 
 * Adds support for async and defer using the 'strategy' argument added for wp_enqueue_script in WordPress 6.3.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## 1.3.8 (unreleased)
 
 * Fix: `Asset_Manager_Preload::set_asset_types()` should return an empty array if no valid arguments are passed.
-* Add: Add `convertDeprecationsToExceptions` to `phpunit.xml`.
+* Add: `convertDeprecationsToExceptions` to `phpunit.xml`.
 
 ## 1.3.7
 

--- a/php/class-asset-manager-preload.php
+++ b/php/class-asset-manager-preload.php
@@ -189,10 +189,14 @@ class Asset_Manager_Preload extends Asset_Manager {
 	 * A MIME type isn't required, but will prevent the browser downloading an
 	 * asset it doesn't support.
 	 *
-	 * @param  array $asset The asset for which the types are needed.
-	 * @return array        The $asset.
+	 * @param array $asset The asset for which the types are needed.
+	 * @return array
 	 */
 	public function set_asset_types( $asset ) {
+		if ( empty( $asset ) || ! isset( $asset['src'] ) ) {
+			return $asset;
+		}
+
 		$path_parts = pathinfo( $asset['src'] );
 
 		if ( empty( $path_parts['extension'] ) ) {
@@ -201,8 +205,8 @@ class Asset_Manager_Preload extends Asset_Manager {
 
 		$asset_types = $this->asset_types[ $path_parts['extension'] ] ?? [];
 
+		// Force these values through.
 		if ( ! empty( $asset_types ) ) {
-			// Force these values through.
 			return array_replace( $asset, $asset_types );
 		}
 

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0"?>
-<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="tests/bootstrap.php" backupGlobals="false" colors="true" convertErrorsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" bootstrap="tests/bootstrap.php" backupGlobals="false" colors="true" convertErrorsToExceptions="true" convertDeprecationsToExceptions="true" convertNoticesToExceptions="true" convertWarningsToExceptions="true" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/9.3/phpunit.xsd">
 	<testsuites>
 		<testsuite name="wp-asset-manager">
 			<directory prefix="test-" suffix=".php">./tests/</directory>

--- a/tests/test-preload.php
+++ b/tests/test-preload.php
@@ -87,6 +87,14 @@ class Asset_Manager_Preload_Tests extends Asset_Manager_Test {
 	 * @group preload
 	 */
 	function test_set_asset_types() {
+		$actual_output = \Asset_Manager_Preload::instance()->set_asset_types( [] );
+
+		$this->assertEquals(
+			$actual_output,
+			[],
+			"Should return an empty array if no arguments are passed"
+		);
+
 		// Adds the expected attributes for preloading a CSS file.
 		$expected_style  = array_merge(
 			$this->test_style,


### PR DESCRIPTION
fixes #64 