### PR TITLE
Allow version argument to be null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,14 @@
 # Change Log
+
 This project adheres to [Semantic Versioning](http://semver.org/).
 
-## 1.4.0
+## 1.4.1
 
+### Fixed
+
+- Ensure that `$version` can be null when passed to helper methods.
+
+## 1.4.0
 
 ### Fixed
 

--- a/package.json
+++ b/package.json
@@ -1,19 +1,19 @@
 {
-  "name": "@alleyinteractive/wp-asset-manager",
-  "version": "1.4.0",
-  "description": "Asset Manager is a toolkit for managing front-end assets and more tightly controlling where, when, and how they're loaded.",
-  "engines": {
-    "node": "22",
-    "npm": "10"
-  },
-  "scripts": {
-    "build": "echo 'No build step defined'",
-    "release": "npx @alleyinteractive/create-release@latest"
-  },
-  "author": "",
-  "license": "GPL-2.0+",
-  "bugs": {
-    "url": "https://github.com/alleyinteractive/wp-asset-manager/issues"
-  },
-  "homepage": "https://github.com/alleyinteractive/wp-asset-manager#readme"
+    "name": "@alleyinteractive/wp-asset-manager",
+    "version": "1.4.1",
+    "description": "Asset Manager is a toolkit for managing front-end assets and more tightly controlling where, when, and how they're loaded.",
+    "engines": {
+        "node": "22",
+        "npm": "10"
+    },
+    "scripts": {
+        "build": "echo 'No build step defined'",
+        "release": "npx @alleyinteractive/create-release@latest"
+    },
+    "author": "",
+    "license": "GPL-2.0+",
+    "bugs": {
+        "url": "https://github.com/alleyinteractive/wp-asset-manager/issues"
+    },
+    "homepage": "https://github.com/alleyinteractive/wp-asset-manager#readme"
 }

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -32,7 +32,17 @@ if ( ! function_exists( 'am_enqueue_script' ) ) :
 	/**
 	 * Load an external script. Options can be passed in as an array or individual parameters.
 	 *
-	 * @phpstan-type EnqueueScriptArgs array{
+	 * @param string|array         $handle Handle for script.
+	 * @param string|null          $src URI to script.
+	 * @param array<string>        $deps This script's dependencies.
+	 * @param array<string>|string $condition Corresponds to a configured loading condition that, if matches,
+	 *                                        will allow the script to load.
+	 *                                        'global' is assumed if no condition is declared.
+	 * @param string               $load_method  How to load this asset.
+	 * @param string|null          $version      Version of the script.
+	 * @param string               $load_hook    Hook on which to load this asset.
+	 *
+	 * @phpstan-param string|array{
 	 *   handle: string,
 	 *   src?: string,
 	 *   condition?: string,
@@ -40,19 +50,9 @@ if ( ! function_exists( 'am_enqueue_script' ) ) :
 	 *   load_hook?: string,
 	 *   load_method?: string,
 	 *   version?: string
-	 * }
-	 *
-	 * @param string|EnqueueScriptArgs $handle Handle for script.
-	 * @param string|null              $src URI to script.
-	 * @param array<string>            $deps This script's dependencies.
-	 * @param array<string>|string     $condition Corresponds to a configured loading condition that, if matches,
-	 *                                            will allow the script to load.
-	 *                                            'global' is assumed if no condition is declared.
-	 * @param string                   $load_method  How to load this asset.
-	 * @param string                   $version      Version of the script.
-	 * @param string                   $load_hook    Hook on which to load this asset.
+	 * } $handle
 	 */
-	function am_enqueue_script( array|string $handle, ?string $src = null, array $deps = [], array|string $condition = 'global', string $load_method = 'sync', string $version = '1.0.0', string $load_hook = 'wp_head' ): void {
+	function am_enqueue_script( array|string $handle, ?string $src = null, array $deps = [], array|string $condition = 'global', string $load_method = 'sync', ?string $version = '1.0.0', string $load_hook = 'wp_head' ): void {
 		$defaults = compact( 'handle', 'src', 'deps', 'condition', 'load_method', 'version', 'load_hook' );
 		$args     = is_array( $handle ) ? array_merge( $defaults, $handle ) : $defaults;
 		Scripts::instance()->add_asset( $args );
@@ -79,7 +79,18 @@ if ( ! function_exists( 'am_enqueue_style' ) ) :
 	/**
 	 * Load an external stylesheet. Options can be passed in as an array or individual parameters.
 	 *
-	 * @phpstan-type EnqueueStyleArgs array{
+	 * @param string|array $handle       Handle for stylesheet. This is necessary for dependency management.
+	 * @param string       $src         URI to stylesheet.
+	 * @param array        $deps        List of dependencies.
+	 * @param array|string $condition   Corresponds to a configured loading condition that, if matches,
+	 *                            will allow the stylesheet to load.
+	 *                            'global' is assumed if no condition is declared.
+	 * @param string       $load_method How to load this asset.
+	 * @param string|null  $version     Version of the script.
+	 * @param string       $load_hook   Hook on which to load this asset.
+	 * @param string       $media       Media query to restrict when this asset is loaded.
+	 *
+	 * @phpstan-param string|array{
 	 *   handle: string,
 	 *   src?: string,
 	 *   deps?: array<string>,
@@ -88,20 +99,9 @@ if ( ! function_exists( 'am_enqueue_style' ) ) :
 	 *   version?: string,
 	 *   load_hook?: string,
 	 *   media?: string
-	 * }
-	 *
-	 * @param string|EnqueueStyleArgs $handle      Handle for stylesheet. This is necessary for dependency management.
-	 * @param string                  $src         URI to stylesheet.
-	 * @param array                   $deps        List of dependencies.
-	 * @param array|string            $condition   Corresponds to a configured loading condition that, if matches,
-	 *                                       will allow the stylesheet to load.
-	 *                                       'global' is assumed if no condition is declared.
-	 * @param string                  $load_method How to load this asset.
-	 * @param string                  $version     Version of the script.
-	 * @param string                  $load_hook   Hook on which to load this asset.
-	 * @param string                  $media       Media query to restrict when this asset is loaded.
+	 * } $handle
 	 */
-	function am_enqueue_style( array|string $handle, ?string $src = null, array $deps = [], array|string $condition = 'global', string $load_method = 'sync', string $version = '1.0.0', string $load_hook = 'wp_head', ?string $media = null ): void {
+	function am_enqueue_style( array|string $handle, ?string $src = null, array $deps = [], array|string $condition = 'global', string $load_method = 'sync', ?string $version = '1.0.0', string $load_hook = 'wp_head', ?string $media = null ): void {
 		$defaults = compact( 'handle', 'src', 'deps', 'condition', 'load_method', 'version', 'load_hook', 'media' );
 		$args     = is_array( $handle ) ? array_merge( $defaults, $handle ) : $defaults;
 
@@ -125,7 +125,19 @@ if ( ! function_exists( 'am_preload' ) ) :
 	/**
 	 * Provide an asset with a `preload` resource hint for the browser to prioritize.
 	 *
-	 * @phpstan-type PreloadArgs array{
+	 * @param array|string $handle       Handle for asset. This is necessary for dependency management.
+	 * @param string       $src          URI to asset.
+	 * @param array|string $condition    Corresponds to a configured loading condition that, if matches,
+	 *                             will allow the asset to load.
+	 *                             'global' is assumed if no condition is declared.
+	 * @param string|null  $version      Version of the asset.
+	 * @param string       $media        Media query to restrict when this asset is loaded.
+	 * @param string       $as           A hint to the browser about what type of asset this is.
+	 *                                   See $preload_as for valid options.
+	 * @param boolean      $crossorigin  Preload this asset cross-origin.
+	 * @param string       $mime_type    The MIME type for the preloaded asset.
+	 *
+	 * @phpstan-param string|array{
 	 *   handle: string,
 	 *   src?: string,
 	 *   condition?: array<string>|string,
@@ -134,21 +146,9 @@ if ( ! function_exists( 'am_preload' ) ) :
 	 *   as?: string,
 	 *   crossorigin?: bool,
 	 *   mime_type?: string
-	 * }
-	 *
-	 * @param string|PreloadArgs $handle       Handle for asset. This is necessary for dependency management.
-	 * @param string             $src          URI to asset.
-	 * @param array|string       $condition    Corresponds to a configured loading condition that, if matches,
-	 *                                   will allow the asset to load.
-	 *                                   'global' is assumed if no condition is declared.
-	 * @param string             $version      Version of the asset.
-	 * @param string             $media        Media query to restrict when this asset is loaded.
-	 * @param string             $as           A hint to the browser about what type of asset this is.
-	 *                                         See $preload_as for valid options.
-	 * @param boolean            $crossorigin  Preload this asset cross-origin.
-	 * @param string             $mime_type    The MIME type for the preloaded asset.
+	 * } $handle Handle for asset. This is necessary for dependency management.
 	 */
-	function am_preload( array|string $handle, ?string $src = null, array|string $condition = 'global', string $version = '1.0.0', string $media = 'all', ?string $as = null, bool $crossorigin = false, ?string $mime_type = null ): void {
+	function am_preload( array|string $handle, ?string $src = null, array|string $condition = 'global', ?string $version = '1.0.0', string $media = 'all', ?string $as = null, bool $crossorigin = false, ?string $mime_type = null ): void {
 		$defaults = compact( 'handle', 'src', 'condition', 'version', 'media', 'as', 'crossorigin', 'mime_type' );
 		$args     = is_array( $handle ) ? array_merge( $defaults, $handle ) : $defaults;
 		Preload::instance()->add_asset( $args );
@@ -161,23 +161,23 @@ if ( ! function_exists( 'am_register_symbol' ) ) :
 	/**
 	 * Define a symbol to be added to the SVG sprite.
 	 *
-	 * @phpstan-type RegisterSymbolArgs array{
+	 * @param string|array $handle     Handle for asset, used to refer to the symbol in `am_use_symbol`.
+	 * @param string       $src        Absolute path from the current theme root, or a relative path
+	 *                                 based on the current theme root. Use the `am_modify_svg_directory`
+	 *                                 filter to update the directory from which relative paths will be
+	 *                                 completed.
+	 * @param array|string $condition  Corresponds to a configured loading condition that, if matches,
+	 *                           will allow the asset to be added to the sprite sheet.
+	 *                           'global' is assumed if no condition is declared.
+	 * @param array        $attributes An array of attribute names and values to add to the resulting <svg>
+	 *                                 everywhere it is printed.
+	 *
+	 * @phpstan-param string|array{
 	 *   handle: string,
 	 *   src?: string,
 	 *   condition?: array<string>|string,
 	 *   attributes?: array<string, string>
-	 * }
-	 *
-	 * @param string|RegisterSymbolArgs $handle     Handle for asset, used to refer to the symbol in `am_use_symbol`.
-	 * @param string                    $src        Absolute path from the current theme root, or a relative path
-	 *                                              based on the current theme root. Use the `am_modify_svg_directory`
-	 *                                              filter to update the directory from which relative paths will be
-	 *                                              completed.
-	 * @param array|string              $condition  Corresponds to a configured loading condition that, if matches,
-	 *                                        will allow the asset to be added to the sprite sheet.
-	 *                                        'global' is assumed if no condition is declared.
-	 * @param array                     $attributes An array of attribute names and values to add to the resulting <svg>
-	 *                                              everywhere it is printed.
+	 * } $handle
 	 */
 	function am_register_symbol( array|string $handle, ?string $src = null, array|string $condition = 'global', array $attributes = [] ): void {
 		$defaults = compact( 'handle', 'src', 'condition', 'attributes' );

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -83,8 +83,8 @@ if ( ! function_exists( 'am_enqueue_style' ) ) :
 	 * @param string       $src         URI to stylesheet.
 	 * @param array        $deps        List of dependencies.
 	 * @param array|string $condition   Corresponds to a configured loading condition that, if matches,
-	 *                            will allow the stylesheet to load.
-	 *                            'global' is assumed if no condition is declared.
+	 *                                  will allow the stylesheet to load.
+	 *                                  'global' is assumed if no condition is declared.
 	 * @param string       $load_method How to load this asset.
 	 * @param string|null  $version     Version of the script.
 	 * @param string       $load_hook   Hook on which to load this asset.
@@ -128,8 +128,8 @@ if ( ! function_exists( 'am_preload' ) ) :
 	 * @param array|string $handle       Handle for asset. This is necessary for dependency management.
 	 * @param string       $src          URI to asset.
 	 * @param array|string $condition    Corresponds to a configured loading condition that, if matches,
-	 *                             will allow the asset to load.
-	 *                             'global' is assumed if no condition is declared.
+	 *                                   will allow the asset to load.
+	 *                                   'global' is assumed if no condition is declared.
 	 * @param string|null  $version      Version of the asset.
 	 * @param string       $media        Media query to restrict when this asset is loaded.
 	 * @param string       $as           A hint to the browser about what type of asset this is.
@@ -167,8 +167,8 @@ if ( ! function_exists( 'am_register_symbol' ) ) :
 	 *                                 filter to update the directory from which relative paths will be
 	 *                                 completed.
 	 * @param array|string $condition  Corresponds to a configured loading condition that, if matches,
-	 *                           will allow the asset to be added to the sprite sheet.
-	 *                           'global' is assumed if no condition is declared.
+	 *                                 will allow the asset to be added to the sprite sheet.
+	 *                                 'global' is assumed if no condition is declared.
 	 * @param array        $attributes An array of attribute names and values to add to the resulting <svg>
 	 *                                 everywhere it is printed.
 	 *

--- a/src/helpers.php
+++ b/src/helpers.php
@@ -79,7 +79,7 @@ if ( ! function_exists( 'am_enqueue_style' ) ) :
 	/**
 	 * Load an external stylesheet. Options can be passed in as an array or individual parameters.
 	 *
-	 * @param string|array $handle       Handle for stylesheet. This is necessary for dependency management.
+	 * @param string|array $handle      Handle for stylesheet. This is necessary for dependency management.
 	 * @param string       $src         URI to stylesheet.
 	 * @param array        $deps        List of dependencies.
 	 * @param array|string $condition   Corresponds to a configured loading condition that, if matches,

--- a/wp-asset-manager.php
+++ b/wp-asset-manager.php
@@ -10,7 +10,7 @@ Plugin Name: Asset Manager
 Plugin URI: https://github.com/alleyinteractive/wp-asset-manager
 Description: Add more robust functionality to enqueuing static assets
 Author: Alley Interactive
-Version: 1.4.0
+Version: 1.4.1
 License: GPLv2 or later
 Author URI: https://alley.com
 */


### PR DESCRIPTION
- Fix a bug with a bad argument type for `$version`.
- Fix PHPStan parameter shape. `@phpstan-type` is only supported for classes.